### PR TITLE
Upload shortcut fix - pass in correct file object

### DIFF
--- a/django_boto/s3/shortcuts.py
+++ b/django_boto/s3/shortcuts.py
@@ -28,6 +28,6 @@ def upload(filename, name=None, prefix=False, bucket_name=False, key=None,
         full_path = name
 
     s3 = S3Storage(bucket_name=bucket_name, key=key, secret=secret, host=host)
-    s3.save(full_path, file)
+    s3.save(full_path, fl)
 
     return s3.url(full_path)


### PR DESCRIPTION
I found an issue when trying to use the upload shortcut.  The file object originally passed doesn't exist, so I changed it to use the fl object that's setup in the upload function.
