### PR TITLE
Fix to open the S3 connection only once needed.

### DIFF
--- a/django_boto/__init__.py
+++ b/django_boto/__init__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '0.2.1'
+__version__ = '0.2.1b'


### PR DESCRIPTION
Hello,

I made this modification so that a S3Storage object so that a S3 connection is opened only once it is really needed. I had noticed that, for example, if you define your s3 storage object in a models.py file of a Django app, the s3 connection is opened on each Django request.

The change I made optimizes this by storing locally the connection settings in the object and making the bucket property dynamic so that it opens a connection when first accessed.
