### PR TITLE
Bugfix: s3.create_bucket can raise an S3ResponseError. Handle it.

### DIFF
--- a/django_boto/s3/storage.py
+++ b/django_boto/s3/storage.py
@@ -39,7 +39,7 @@ class S3Storage(Storage):
             self.s3 = connect_s3(self.key, self.secret)
             try:
                 self._bucket = self.s3.create_bucket(self.bucket_name, location=self.location)
-            except S3CreateError, S3ResponseError:
+            except (S3CreateError, S3ResponseError):
                 self._bucket = self.s3.get_bucket(self.bucket_name)
         return self._bucket
 


### PR DESCRIPTION
Bugfix: s3.create_bucket can raise an S3ResponseError, not only an S3CreateError.
