### PR TITLE
django.core.files.storage._open() expects a different _open() signature

### DIFF
--- a/django_boto/s3/storage.py
+++ b/django_boto/s3/storage.py
@@ -83,7 +83,7 @@ class S3Storage(Storage):
         key = self.bucket.get_key(name)
         return key.generate_url(expires, query_auth=query_auth, force_http=force_http)
 
-    def _open(self, name):
+    def _open(self, name, mode='rb'):
         """
         Open file.
         """


### PR DESCRIPTION
see: https://github.com/django/django/blob/master/django/core/files/storage.py#L30
