### PR TITLE
Add @deconstructible decorator to S3Storage to enable serialization.

### DIFF
--- a/django_boto/s3/storage.py
+++ b/django_boto/s3/storage.py
@@ -35,7 +35,8 @@ class S3Storage(Storage):
         self.force_http = force_http_url if force_http_url else settings.AWS_S3_FORCE_HTTP_URL
         self.replace = replace
 
-        self.location = getattr(Location, self.location)
+        if hasattr(Location, self.location):
+            self.location = getattr(Location, self.location)
 
         self._bucket = None
 


### PR DESCRIPTION
Under Django 1.7, using 'makemigrations' command fails when an S3Storage() is not serializable.
