### PR TITLE
Added support for Django 1.10

### DIFF
--- a/django_boto/s3/storage.py
+++ b/django_boto/s3/storage.py
@@ -148,7 +148,7 @@ class S3Storage(Storage):
 
         return name
 
-    def get_available_name(self, name):
+    def get_available_name(self, name, max_length=None):
         """
         Returns a filename that's free on the target storage system, and
         available for new content to be written to.


### PR DESCRIPTION
max_length was optional in Django 1.9 [1] but mandatory in 1.10 [2]

[1] https://github.com/django/django/blob/1.9/django/core/files/storage.py#L52
[2] https://github.com/django/django/blob/1.10/django/core/files/storage.py#L53