### PR TITLE
Adding is_secure parameter as False

### DIFF
--- a/django_boto/s3/storage.py
+++ b/django_boto/s3/storage.py
@@ -30,7 +30,7 @@ class S3Storage(Storage):
     """
 
     def __init__(self, bucket_name=None, key=None, secret=None, location=None,
-                 host=None, policy=None, replace=True, force_http_url=False):
+                 host=None, policy=None, replace=True, force_http_url=False, is_secure = False):
 
         self.bucket_name = bucket_name if bucket_name else settings.BOTO_S3_BUCKET
         self.key = key if key else settings.AWS_ACCESS_KEY_ID
@@ -40,7 +40,7 @@ class S3Storage(Storage):
         self.policy = policy if policy else settings.AWS_ACL_POLICY
         self.force_http = force_http_url if force_http_url else settings.AWS_S3_FORCE_HTTP_URL
         self.replace = replace
-
+        self.is_secure = is_secure
         if hasattr(Location, self.location):
             self.location = getattr(Location, self.location)
 
@@ -52,7 +52,7 @@ class S3Storage(Storage):
             self.s3 = connect_s3(
                 aws_access_key_id=self.key,
                 aws_secret_access_key=self.secret,
-                host=self.host)
+                host=self.host, is_secure = self.is_secure)
             try:
                 self._bucket = self.s3.create_bucket(
                     self.bucket_name, location=self.location, policy=self.policy)


### PR DESCRIPTION
s3for.me aws 3 compatible cloud works on boto==2.49 v2 but it needs is_secure=false to connect their cloud. So I added optional paramater as False to work s3for.me. On aws, user can set parameter to True on S3Storage(is_secure=True) 